### PR TITLE
Blur tile lines

### DIFF
--- a/Tilebots.html
+++ b/Tilebots.html
@@ -553,6 +553,8 @@ Bot.prototype.draw = function(fixed) {
 	ctx.fillStyle = this.color;
 	ctx.strokeStyle = this.color;
 	ctx.lineWidth = 0.04;
+	ctx.shadowColor = this.color;
+	ctx.shadowBlur = 0.1;
 	for(var i in this.map.cellArr) {
 		this.drawTile(this.map.cellArr[i]);
 	}


### PR DESCRIPTION
Make the vector graphics look a little more full and soft by adding a little shadow to the lines to blur them.